### PR TITLE
Colab support

### DIFF
--- a/docs/tutorials/paprika_colab_init.ipynb
+++ b/docs/tutorials/paprika_colab_init.ipynb
@@ -1,0 +1,270 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "name": "paprika_colab_init.ipynb",
+      "provenance": [],
+      "collapsed_sections": []
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    },
+    "accelerator": "GPU"
+  },
+  "cells": [
+    {
+      "cell_type": "code",
+      "source": [
+        "script = \"\"\"\n",
+        "#!/bin/bash\n",
+        "\n",
+        "#Download the miniconda setup script\n",
+        "echo $(rm *Miniconda3-latest-Linux-x86_64.sh*)\n",
+        "echo $(wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh)\n",
+        "\n",
+        "#Get the SHA-256 hashsum of the script\n",
+        "current_hash=$(sha256sum Miniconda3-latest-Linux-x86_64.sh)\n",
+        "\n",
+        "#Reference hash from https://docs.conda.io/en/latest/miniconda.html retrieved April 2022\n",
+        "reference_hash=\"4ee9c3aa53329cd7a63b49877c0babb49b19b7e5af29807b793a76bdb1d362b4  Miniconda3-latest-Linux-x86_64.sh\"\n",
+        "\n",
+        "echo Verifying Miniconda hash...\n",
+        "echo $current_hash ; echo $reference_hash\n",
+        "\n",
+        "#Check if the hashes match\n",
+        "if [ \"$current_hash\" == \"$reference_hash\" ]; then\n",
+        "  echo Hash verified. Continuing with installation...\n",
+        "  bash Miniconda3-latest-Linux-x86_64.sh -b -f -p /usr/local\n",
+        "else\n",
+        "  echo Hash verification failed. Make sure the reference_hash variable in download_miniconda.sh matches the most recent hash at https://docs.conda.io/en/latest/miniconda.html. Installation halted.\n",
+        "  echo $(rm *Miniconda3-latest-Linux-x86_64.sh*)\n",
+        "fi\n",
+        "\n",
+        "echo Exiting Miniconda installation script.\n",
+        "\"\"\"\n",
+        "with open('download_miniconda.sh', 'w') as file:\n",
+        "  file.write(script)\n",
+        "\n",
+        "!chmod +x download_miniconda.sh; bash download_miniconda.sh"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "znDiDP1cPs18",
+        "outputId": "8bc658b9-3ad3-45ba-dfd2-f39bea3968bb",
+        "collapsed": true
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "\n",
+            "--2022-04-30 04:41:39--  https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh\n",
+            "Resolving repo.anaconda.com (repo.anaconda.com)... 104.16.130.3, 104.16.131.3, 2606:4700::6810:8303, ...\n",
+            "Connecting to repo.anaconda.com (repo.anaconda.com)|104.16.130.3|:443... connected.\n",
+            "HTTP request sent, awaiting response... 200 OK\n",
+            "Length: 75660608 (72M) [application/x-sh]\n",
+            "Saving to: ‘Miniconda3-latest-Linux-x86_64.sh’\n",
+            "\n",
+            "Miniconda3-latest-L 100%[===================>]  72.16M   165MB/s    in 0.4s    \n",
+            "\n",
+            "2022-04-30 04:41:40 (165 MB/s) - ‘Miniconda3-latest-Linux-x86_64.sh’ saved [75660608/75660608]\n",
+            "\n",
+            "\n",
+            "Verifying Miniconda hash...\n",
+            "4ee9c3aa53329cd7a63b49877c0babb49b19b7e5af29807b793a76bdb1d362b4 Miniconda3-latest-Linux-x86_64.sh\n",
+            "4ee9c3aa53329cd7a63b49877c0babb49b19b7e5af29807b793a76bdb1d362b4 Miniconda3-latest-Linux-x86_64.sh\n",
+            "Hash verified. Continuing with installation...\n",
+            "PREFIX=/usr/local\n",
+            "Unpacking payload ...\n",
+            "Collecting package metadata (current_repodata.json): - \b\b\\ \b\b| \b\bdone\n",
+            "Solving environment: - \b\b\\ \b\b| \b\bdone\n",
+            "\n",
+            "# All requested packages already installed.\n",
+            "\n",
+            "installation finished.\n",
+            "WARNING:\n",
+            "    You currently have a PYTHONPATH environment variable set. This may cause\n",
+            "    unexpected behavior when running the Python interpreter in Miniconda3.\n",
+            "    For best results, please verify that your PYTHONPATH only points to\n",
+            "    directories of packages that are compatible with the Python interpreter\n",
+            "    in Miniconda3: /usr/local\n",
+            "Exiting Miniconda installation script.\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "MPKcMqiVOBLT",
+        "collapsed": true
+      },
+      "outputs": [],
+      "source": [
+        "!unset PYTHONPATH\n",
+        "!export PATH=\"/root/miniconda/bin:$PATH\"\n",
+        "!source /root/.bashrc"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!git clone https://github.com/slochower/pAPRika.git\n",
+        "!source /usr/local/etc/profile.d/conda.sh; conda env create --name paprika --file pAPRika/devtools/conda-envs/test_env.yaml && conda list\n",
+        "!source /usr/local/etc/profile.d/conda.sh; conda init bash\n",
+        "!source /usr/local/etc/profile.d/conda.sh; conda activate paprika\n",
+        "!source /usr/local/etc/profile.d/conda.sh; pip install git+https://github.com/slochower/pAPRika.git@master\n",
+        "!source /usr/local/etc/profile.d/conda.sh; pip install ."
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "8QxCvQS8mnjN",
+        "outputId": "74daeddb-7a0e-4cb3-fe61-23b80be4de80"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "fatal: destination path 'pAPRika' already exists and is not an empty directory.\n",
+            "\n",
+            "CondaValueError: prefix already exists: /usr/local/envs/paprika\n",
+            "\n",
+            "no change     /usr/local/condabin/conda\n",
+            "no change     /usr/local/bin/conda\n",
+            "no change     /usr/local/bin/conda-env\n",
+            "no change     /usr/local/bin/activate\n",
+            "no change     /usr/local/bin/deactivate\n",
+            "no change     /usr/local/etc/profile.d/conda.sh\n",
+            "no change     /usr/local/etc/fish/conf.d/conda.fish\n",
+            "no change     /usr/local/shell/condabin/Conda.psm1\n",
+            "no change     /usr/local/shell/condabin/conda-hook.ps1\n",
+            "no change     /usr/local/lib/python3.9/site-packages/xontrib/conda.xsh\n",
+            "no change     /usr/local/etc/profile.d/conda.csh\n",
+            "no change     /root/.bashrc\n",
+            "No action taken.\n",
+            "Collecting git+https://github.com/slochower/pAPRika.git@master\n",
+            "  Cloning https://github.com/slochower/pAPRika.git (to revision master) to /tmp/pip-req-build-e3hhxi48\n",
+            "  Running command git clone -q https://github.com/slochower/pAPRika.git /tmp/pip-req-build-e3hhxi48\n",
+            "  Resolved https://github.com/slochower/pAPRika.git to commit 5376f44ee1f7a0785f712b3b6c7bfa4c698ca65e\n",
+            "Requirement already satisfied: numpy in /usr/local/lib/python3.9/site-packages (from paprika==1.1.0+52.g5376f44) (1.22.3)\n",
+            "\u001b[33mWARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv\u001b[0m\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!source /usr/local/etc/profile.d/conda.sh; pip install pytraj && conda activate paprika\n",
+        "import sys\n",
+        "sys.path.append('/usr/local/lib/python3.9/site-packages/')"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 1000
+        },
+        "id": "7PGZfe6NPJYT",
+        "outputId": "4998d1d8-2bc1-43d6-bdab-c9fcfa7a4f25",
+        "collapsed": true
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Collecting pytraj\n",
+            "  Downloading pytraj-2.0.5.tar.gz (20.3 MB)\n",
+            "\u001b[K     |████████████████████████████████| 20.3 MB 1.2 MB/s \n",
+            "\u001b[33mWARNING: Discarding https://files.pythonhosted.org/packages/ab/c0/6bf4ef6bbc360452266da5259d74b8c05ab84051a3a302578f647392f274/pytraj-2.0.5.tar.gz#sha256=4326dde78ef2c85c145d130fda27bce302c3d2e7862ceeb0911b76d7cdee3385 (from https://pypi.org/simple/pytraj/). Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.\u001b[0m\n",
+            "\u001b[?25h  Downloading pytraj-2.0.4.tar.gz (20.3 MB)\n",
+            "\u001b[K     |████████████████████████████████| 20.3 MB 76.4 MB/s \n",
+            "\u001b[33mWARNING: Discarding https://files.pythonhosted.org/packages/fc/de/63d14c89e31823c93c63e5ee658be826b4bc9cc1cba5e50fd883d1d1f507/pytraj-2.0.4.tar.gz#sha256=0ad7f91feec4b6afb3d85bde12861313b4f5d1979416b0e5dda6ef06ecdf545c (from https://pypi.org/simple/pytraj/). Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.\u001b[0m\n",
+            "\u001b[?25h  Downloading pytraj-2.0.3.tar.gz (20.2 MB)\n",
+            "\u001b[K     |████████████████████████████████| 20.2 MB 1.2 MB/s \n",
+            "\u001b[33mWARNING: Discarding https://files.pythonhosted.org/packages/74/d8/c1cb815b86bb275c23b2f3f83597401a421feb43f72fb7ce7475279464d2/pytraj-2.0.3.tar.gz#sha256=74879db0cd9d035447dff65333f0779450079c12d606af1869a531a0bcb69f7c (from https://pypi.org/simple/pytraj/). Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.\u001b[0m\n",
+            "\u001b[?25h  Downloading pytraj-2.0.2.tar.gz (20.1 MB)\n",
+            "\u001b[K     |████████████████████████████████| 20.1 MB 1.2 MB/s \n",
+            "\u001b[33mWARNING: Discarding https://files.pythonhosted.org/packages/7c/cf/6e6860dd8638a07854a0d245241a9ba3efa14564042743b62ae77f059c38/pytraj-2.0.2.tar.gz#sha256=0ba601d72a7a5f139c9a3e7d2247f93693dbd12360dd421477d12a0518c00abc (from https://pypi.org/simple/pytraj/). Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.\u001b[0m\n",
+            "\u001b[?25h  Downloading pytraj-2.0.1.tar.gz (20.1 MB)\n",
+            "\u001b[K     |████████████████████████████████| 20.1 MB 105 kB/s \n",
+            "\u001b[33mWARNING: Discarding https://files.pythonhosted.org/packages/37/82/ba2933c49cced778682b97f71cf4bc5c18a043aecf32b05188515afebd67/pytraj-2.0.1.tar.gz#sha256=72d3a874dc4e54fadc582d7dd5e4deac6e00c8975103ece31ce8cc10f9bed2f8 (from https://pypi.org/simple/pytraj/). Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.\u001b[0m\n",
+            "\u001b[?25h  Downloading pytraj-1.0.9.tar.gz (19.9 MB)\n",
+            "\u001b[K     |████████████████████████████████| 19.9 MB 9.8 MB/s \n",
+            "\u001b[33mWARNING: Discarding https://files.pythonhosted.org/packages/dd/00/308ac87d0e42c07f3e3dba57febe088bc8dbac02299477b0f62157906538/pytraj-1.0.9.tar.gz#sha256=8fe1d1c5ff5f78088fc0cb0f917c011e903f10aaddae2bbd71e5f69afe8583d2 (from https://pypi.org/simple/pytraj/). Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.\u001b[0m\n",
+            "\u001b[?25h  Downloading pytraj-1.0.7.tar.gz (36.4 MB)\n",
+            "\u001b[K     |████████████████████████████████| 36.4 MB 107 kB/s \n",
+            "\u001b[33mWARNING: Discarding https://files.pythonhosted.org/packages/cf/7b/33256bbb7f6747f1ea1a35f71bca623e426747d269a0e982639ed9ec7279/pytraj-1.0.7.tar.gz#sha256=9188e28e7c96f0657a8d5dbf79aa565d12c3a851854747a77e6448ddd6e374d4 (from https://pypi.org/simple/pytraj/). Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.\u001b[0m\n",
+            "\u001b[?25h  Downloading pytraj-1.0.6.tar.gz (30.2 MB)\n",
+            "\u001b[K     |████████████████████████████████| 30.2 MB 143 kB/s \n",
+            "\u001b[33mWARNING: Discarding https://files.pythonhosted.org/packages/2a/ea/c29d67b2ab66ea74b6056f985023d7e384a16d5b63a466325f9896092581/pytraj-1.0.6.tar.gz#sha256=af80d0f78fd6efe28d1711e476661171db5abf50339983022ef2cdb7e50b4c28 (from https://pypi.org/simple/pytraj/). Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.\u001b[0m\n",
+            "\u001b[?25h  Downloading pytraj-1.0.3.tar.gz (29.2 MB)\n",
+            "\u001b[K     |████████████████████████████████| 29.2 MB 87 kB/s \n",
+            "\u001b[33mWARNING: Discarding https://files.pythonhosted.org/packages/25/a2/2689e95c76b0d4fa0d7e05ca6bb682a250601271da10de93039e984fd366/pytraj-1.0.3.tar.gz#sha256=f7c09f26a6cd44a38d6fa7b979224ce3ecae4845bb51547e2fd2a90a40a56905 (from https://pypi.org/simple/pytraj/). Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.\u001b[0m\n",
+            "\u001b[?25h  Downloading pytraj-1.0.2.tar.gz (29.5 MB)\n",
+            "\u001b[K     |████████████████████████████████| 29.5 MB 1.3 MB/s \n",
+            "\u001b[33mWARNING: Discarding https://files.pythonhosted.org/packages/6d/88/a01239354d6811838f426cbaaf9080a57dca36f64f58afdb1c8f0a9d7262/pytraj-1.0.2.tar.gz#sha256=3c369d46ee1576ec3226b4c1eb46e74ce0829470dc8f4fc494176ee54cc39bd8 (from https://pypi.org/simple/pytraj/). Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.\u001b[0m\n",
+            "\u001b[?25h  Downloading pytraj-1.0.1.tar.gz (29.5 MB)\n",
+            "\u001b[K     |████████████████████████████████| 29.5 MB 72 kB/s \n",
+            "\u001b[33mWARNING: Discarding https://files.pythonhosted.org/packages/d0/63/400bd3b40629628b928c7dd8d1758fad47164e50cc718f740f498db06a76/pytraj-1.0.1.tar.gz#sha256=a89e244cef3c63b9dcd3008a65c8196efad71cecf20f51fb748a33f9489e47ab (from https://pypi.org/simple/pytraj/). Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.\u001b[0m\n",
+            "\u001b[31mERROR: Could not find a version that satisfies the requirement pytraj (from versions: 1.0.0b0, 1.0.1, 1.0.2, 1.0.3, 1.0.6, 1.0.7, 1.0.9, 2.0.1, 2.0.2, 2.0.3, 2.0.4, 2.0.5)\u001b[0m\n",
+            "\u001b[31mERROR: No matching distribution found for pytraj\u001b[0m\n",
+            "\u001b[?25h"
+          ]
+        },
+        {
+          "output_type": "error",
+          "ename": "ModuleNotFoundError",
+          "evalue": "ignored",
+          "traceback": [
+            "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+            "\u001b[0;31mModuleNotFoundError\u001b[0m                       Traceback (most recent call last)",
+            "\u001b[0;32m<ipython-input-11-617fe0ac1d08>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0msys\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      3\u001b[0m \u001b[0msys\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mpath\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mappend\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'/usr/local/lib/python3.9/site-packages/'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 4\u001b[0;31m \u001b[0;32mimport\u001b[0m \u001b[0mpaprika\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+            "\u001b[0;32m/usr/local/lib/python3.9/site-packages/paprika/__init__.py\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      9\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mlogging\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     10\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 11\u001b[0;31m \u001b[0;32mfrom\u001b[0m \u001b[0mpaprika\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mevaluator\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mAnalyze\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     12\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     13\u001b[0m \u001b[0;31m# Handle versioneer\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;32m/usr/local/lib/python3.9/site-packages/paprika/evaluator/__init__.py\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0;32mfrom\u001b[0m \u001b[0;34m.\u001b[0m\u001b[0manalyze\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mAnalyze\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      2\u001b[0m \u001b[0;32mfrom\u001b[0m \u001b[0;34m.\u001b[0m\u001b[0msetup\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mSetup\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      3\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      4\u001b[0m __all__ = [\n\u001b[1;32m      5\u001b[0m     \u001b[0mAnalyze\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;32m/usr/local/lib/python3.9/site-packages/paprika/evaluator/analyze.py\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      8\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mnumpy\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0mnp\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      9\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 10\u001b[0;31m \u001b[0;32mfrom\u001b[0m \u001b[0mpaprika\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0manalysis\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mfe_calc\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     11\u001b[0m \u001b[0;32mfrom\u001b[0m \u001b[0mpaprika\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mrestraints\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mDAT_restraint\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     12\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;32m/usr/local/lib/python3.9/site-packages/paprika/analysis.py\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      8\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mnumpy\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0mnp\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      9\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mpymbar\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 10\u001b[0;31m \u001b[0;32mimport\u001b[0m \u001b[0mpytraj\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0mpt\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     11\u001b[0m \u001b[0;32mfrom\u001b[0m \u001b[0mopenff\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0munits\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0munit\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     12\u001b[0m \u001b[0;32mfrom\u001b[0m \u001b[0mpymbar\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mtimeseries\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;31mModuleNotFoundError\u001b[0m: No module named 'pytraj'",
+            "",
+            "\u001b[0;31m---------------------------------------------------------------------------\u001b[0;32m\nNOTE: If your import is failing due to a missing package, you can\nmanually install dependencies using either !pip or !apt.\n\nTo view examples of installing some common dependencies, click the\n\"Open Examples\" button below.\n\u001b[0;31m---------------------------------------------------------------------------\u001b[0m\n"
+          ],
+          "errorDetails": {
+            "actions": [
+              {
+                "action": "open_url",
+                "actionText": "Open Examples",
+                "url": "/notebooks/snippets/importing_libraries.ipynb"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        ""
+      ],
+      "metadata": {
+        "id": "6QHHmmcNs48d"
+      },
+      "execution_count": null,
+      "outputs": []
+    }
+  ]
+}

--- a/docs/tutorials/paprika_colab_init.ipynb
+++ b/docs/tutorials/paprika_colab_init.ipynb
@@ -53,54 +53,11 @@
         "!chmod +x download_miniconda.sh; bash download_miniconda.sh"
       ],
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
         "id": "znDiDP1cPs18",
-        "outputId": "8bc658b9-3ad3-45ba-dfd2-f39bea3968bb",
         "collapsed": true
       },
       "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "\n",
-            "--2022-04-30 04:41:39--  https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh\n",
-            "Resolving repo.anaconda.com (repo.anaconda.com)... 104.16.130.3, 104.16.131.3, 2606:4700::6810:8303, ...\n",
-            "Connecting to repo.anaconda.com (repo.anaconda.com)|104.16.130.3|:443... connected.\n",
-            "HTTP request sent, awaiting response... 200 OK\n",
-            "Length: 75660608 (72M) [application/x-sh]\n",
-            "Saving to: ‘Miniconda3-latest-Linux-x86_64.sh’\n",
-            "\n",
-            "Miniconda3-latest-L 100%[===================>]  72.16M   165MB/s    in 0.4s    \n",
-            "\n",
-            "2022-04-30 04:41:40 (165 MB/s) - ‘Miniconda3-latest-Linux-x86_64.sh’ saved [75660608/75660608]\n",
-            "\n",
-            "\n",
-            "Verifying Miniconda hash...\n",
-            "4ee9c3aa53329cd7a63b49877c0babb49b19b7e5af29807b793a76bdb1d362b4 Miniconda3-latest-Linux-x86_64.sh\n",
-            "4ee9c3aa53329cd7a63b49877c0babb49b19b7e5af29807b793a76bdb1d362b4 Miniconda3-latest-Linux-x86_64.sh\n",
-            "Hash verified. Continuing with installation...\n",
-            "PREFIX=/usr/local\n",
-            "Unpacking payload ...\n",
-            "Collecting package metadata (current_repodata.json): - \b\b\\ \b\b| \b\bdone\n",
-            "Solving environment: - \b\b\\ \b\b| \b\bdone\n",
-            "\n",
-            "# All requested packages already installed.\n",
-            "\n",
-            "installation finished.\n",
-            "WARNING:\n",
-            "    You currently have a PYTHONPATH environment variable set. This may cause\n",
-            "    unexpected behavior when running the Python interpreter in Miniconda3.\n",
-            "    For best results, please verify that your PYTHONPATH only points to\n",
-            "    directories of packages that are compatible with the Python interpreter\n",
-            "    in Miniconda3: /usr/local\n",
-            "Exiting Miniconda installation script.\n"
-          ]
-        }
-      ]
+      "outputs": []
     },
     {
       "cell_type": "code",
@@ -125,44 +82,10 @@
         "!pip install git+https://github.com/slochower/pAPRika.git@master"
       ],
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "8QxCvQS8mnjN",
-        "outputId": "74daeddb-7a0e-4cb3-fe61-23b80be4de80"
+        "id": "8QxCvQS8mnjN"
       },
       "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "fatal: destination path 'pAPRika' already exists and is not an empty directory.\n",
-            "\n",
-            "CondaValueError: prefix already exists: /usr/local/envs/paprika\n",
-            "\n",
-            "no change     /usr/local/condabin/conda\n",
-            "no change     /usr/local/bin/conda\n",
-            "no change     /usr/local/bin/conda-env\n",
-            "no change     /usr/local/bin/activate\n",
-            "no change     /usr/local/bin/deactivate\n",
-            "no change     /usr/local/etc/profile.d/conda.sh\n",
-            "no change     /usr/local/etc/fish/conf.d/conda.fish\n",
-            "no change     /usr/local/shell/condabin/Conda.psm1\n",
-            "no change     /usr/local/shell/condabin/conda-hook.ps1\n",
-            "no change     /usr/local/lib/python3.9/site-packages/xontrib/conda.xsh\n",
-            "no change     /usr/local/etc/profile.d/conda.csh\n",
-            "no change     /root/.bashrc\n",
-            "No action taken.\n",
-            "Collecting git+https://github.com/slochower/pAPRika.git@master\n",
-            "  Cloning https://github.com/slochower/pAPRika.git (to revision master) to /tmp/pip-req-build-e3hhxi48\n",
-            "  Running command git clone -q https://github.com/slochower/pAPRika.git /tmp/pip-req-build-e3hhxi48\n",
-            "  Resolved https://github.com/slochower/pAPRika.git to commit 5376f44ee1f7a0785f712b3b6c7bfa4c698ca65e\n",
-            "Requirement already satisfied: numpy in /usr/local/lib/python3.9/site-packages (from paprika==1.1.0+52.g5376f44) (1.22.3)\n",
-            "\u001b[33mWARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv\u001b[0m\n"
-          ]
-        }
-      ]
+      "outputs": []
     },
     {
       "cell_type": "code",
@@ -173,94 +96,8 @@
         "os.environ[\"CUDA_VISIBLE_DEVICES\"] = \"0\""
       ],
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 1000
-        },
         "id": "7PGZfe6NPJYT",
-        "outputId": "4998d1d8-2bc1-43d6-bdab-c9fcfa7a4f25",
         "collapsed": true
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Collecting pytraj\n",
-            "  Downloading pytraj-2.0.5.tar.gz (20.3 MB)\n",
-            "\u001b[K     |████████████████████████████████| 20.3 MB 1.2 MB/s \n",
-            "\u001b[33mWARNING: Discarding https://files.pythonhosted.org/packages/ab/c0/6bf4ef6bbc360452266da5259d74b8c05ab84051a3a302578f647392f274/pytraj-2.0.5.tar.gz#sha256=4326dde78ef2c85c145d130fda27bce302c3d2e7862ceeb0911b76d7cdee3385 (from https://pypi.org/simple/pytraj/). Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.\u001b[0m\n",
-            "\u001b[?25h  Downloading pytraj-2.0.4.tar.gz (20.3 MB)\n",
-            "\u001b[K     |████████████████████████████████| 20.3 MB 76.4 MB/s \n",
-            "\u001b[33mWARNING: Discarding https://files.pythonhosted.org/packages/fc/de/63d14c89e31823c93c63e5ee658be826b4bc9cc1cba5e50fd883d1d1f507/pytraj-2.0.4.tar.gz#sha256=0ad7f91feec4b6afb3d85bde12861313b4f5d1979416b0e5dda6ef06ecdf545c (from https://pypi.org/simple/pytraj/). Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.\u001b[0m\n",
-            "\u001b[?25h  Downloading pytraj-2.0.3.tar.gz (20.2 MB)\n",
-            "\u001b[K     |████████████████████████████████| 20.2 MB 1.2 MB/s \n",
-            "\u001b[33mWARNING: Discarding https://files.pythonhosted.org/packages/74/d8/c1cb815b86bb275c23b2f3f83597401a421feb43f72fb7ce7475279464d2/pytraj-2.0.3.tar.gz#sha256=74879db0cd9d035447dff65333f0779450079c12d606af1869a531a0bcb69f7c (from https://pypi.org/simple/pytraj/). Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.\u001b[0m\n",
-            "\u001b[?25h  Downloading pytraj-2.0.2.tar.gz (20.1 MB)\n",
-            "\u001b[K     |████████████████████████████████| 20.1 MB 1.2 MB/s \n",
-            "\u001b[33mWARNING: Discarding https://files.pythonhosted.org/packages/7c/cf/6e6860dd8638a07854a0d245241a9ba3efa14564042743b62ae77f059c38/pytraj-2.0.2.tar.gz#sha256=0ba601d72a7a5f139c9a3e7d2247f93693dbd12360dd421477d12a0518c00abc (from https://pypi.org/simple/pytraj/). Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.\u001b[0m\n",
-            "\u001b[?25h  Downloading pytraj-2.0.1.tar.gz (20.1 MB)\n",
-            "\u001b[K     |████████████████████████████████| 20.1 MB 105 kB/s \n",
-            "\u001b[33mWARNING: Discarding https://files.pythonhosted.org/packages/37/82/ba2933c49cced778682b97f71cf4bc5c18a043aecf32b05188515afebd67/pytraj-2.0.1.tar.gz#sha256=72d3a874dc4e54fadc582d7dd5e4deac6e00c8975103ece31ce8cc10f9bed2f8 (from https://pypi.org/simple/pytraj/). Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.\u001b[0m\n",
-            "\u001b[?25h  Downloading pytraj-1.0.9.tar.gz (19.9 MB)\n",
-            "\u001b[K     |████████████████████████████████| 19.9 MB 9.8 MB/s \n",
-            "\u001b[33mWARNING: Discarding https://files.pythonhosted.org/packages/dd/00/308ac87d0e42c07f3e3dba57febe088bc8dbac02299477b0f62157906538/pytraj-1.0.9.tar.gz#sha256=8fe1d1c5ff5f78088fc0cb0f917c011e903f10aaddae2bbd71e5f69afe8583d2 (from https://pypi.org/simple/pytraj/). Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.\u001b[0m\n",
-            "\u001b[?25h  Downloading pytraj-1.0.7.tar.gz (36.4 MB)\n",
-            "\u001b[K     |████████████████████████████████| 36.4 MB 107 kB/s \n",
-            "\u001b[33mWARNING: Discarding https://files.pythonhosted.org/packages/cf/7b/33256bbb7f6747f1ea1a35f71bca623e426747d269a0e982639ed9ec7279/pytraj-1.0.7.tar.gz#sha256=9188e28e7c96f0657a8d5dbf79aa565d12c3a851854747a77e6448ddd6e374d4 (from https://pypi.org/simple/pytraj/). Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.\u001b[0m\n",
-            "\u001b[?25h  Downloading pytraj-1.0.6.tar.gz (30.2 MB)\n",
-            "\u001b[K     |████████████████████████████████| 30.2 MB 143 kB/s \n",
-            "\u001b[33mWARNING: Discarding https://files.pythonhosted.org/packages/2a/ea/c29d67b2ab66ea74b6056f985023d7e384a16d5b63a466325f9896092581/pytraj-1.0.6.tar.gz#sha256=af80d0f78fd6efe28d1711e476661171db5abf50339983022ef2cdb7e50b4c28 (from https://pypi.org/simple/pytraj/). Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.\u001b[0m\n",
-            "\u001b[?25h  Downloading pytraj-1.0.3.tar.gz (29.2 MB)\n",
-            "\u001b[K     |████████████████████████████████| 29.2 MB 87 kB/s \n",
-            "\u001b[33mWARNING: Discarding https://files.pythonhosted.org/packages/25/a2/2689e95c76b0d4fa0d7e05ca6bb682a250601271da10de93039e984fd366/pytraj-1.0.3.tar.gz#sha256=f7c09f26a6cd44a38d6fa7b979224ce3ecae4845bb51547e2fd2a90a40a56905 (from https://pypi.org/simple/pytraj/). Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.\u001b[0m\n",
-            "\u001b[?25h  Downloading pytraj-1.0.2.tar.gz (29.5 MB)\n",
-            "\u001b[K     |████████████████████████████████| 29.5 MB 1.3 MB/s \n",
-            "\u001b[33mWARNING: Discarding https://files.pythonhosted.org/packages/6d/88/a01239354d6811838f426cbaaf9080a57dca36f64f58afdb1c8f0a9d7262/pytraj-1.0.2.tar.gz#sha256=3c369d46ee1576ec3226b4c1eb46e74ce0829470dc8f4fc494176ee54cc39bd8 (from https://pypi.org/simple/pytraj/). Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.\u001b[0m\n",
-            "\u001b[?25h  Downloading pytraj-1.0.1.tar.gz (29.5 MB)\n",
-            "\u001b[K     |████████████████████████████████| 29.5 MB 72 kB/s \n",
-            "\u001b[33mWARNING: Discarding https://files.pythonhosted.org/packages/d0/63/400bd3b40629628b928c7dd8d1758fad47164e50cc718f740f498db06a76/pytraj-1.0.1.tar.gz#sha256=a89e244cef3c63b9dcd3008a65c8196efad71cecf20f51fb748a33f9489e47ab (from https://pypi.org/simple/pytraj/). Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.\u001b[0m\n",
-            "\u001b[31mERROR: Could not find a version that satisfies the requirement pytraj (from versions: 1.0.0b0, 1.0.1, 1.0.2, 1.0.3, 1.0.6, 1.0.7, 1.0.9, 2.0.1, 2.0.2, 2.0.3, 2.0.4, 2.0.5)\u001b[0m\n",
-            "\u001b[31mERROR: No matching distribution found for pytraj\u001b[0m\n",
-            "\u001b[?25h"
-          ]
-        },
-        {
-          "output_type": "error",
-          "ename": "ModuleNotFoundError",
-          "evalue": "ignored",
-          "traceback": [
-            "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-            "\u001b[0;31mModuleNotFoundError\u001b[0m                       Traceback (most recent call last)",
-            "\u001b[0;32m<ipython-input-11-617fe0ac1d08>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0msys\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      3\u001b[0m \u001b[0msys\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mpath\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mappend\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'/usr/local/lib/python3.9/site-packages/'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 4\u001b[0;31m \u001b[0;32mimport\u001b[0m \u001b[0mpaprika\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-            "\u001b[0;32m/usr/local/lib/python3.9/site-packages/paprika/__init__.py\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      9\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mlogging\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     10\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 11\u001b[0;31m \u001b[0;32mfrom\u001b[0m \u001b[0mpaprika\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mevaluator\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mAnalyze\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     12\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     13\u001b[0m \u001b[0;31m# Handle versioneer\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-            "\u001b[0;32m/usr/local/lib/python3.9/site-packages/paprika/evaluator/__init__.py\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0;32mfrom\u001b[0m \u001b[0;34m.\u001b[0m\u001b[0manalyze\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mAnalyze\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      2\u001b[0m \u001b[0;32mfrom\u001b[0m \u001b[0;34m.\u001b[0m\u001b[0msetup\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mSetup\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      3\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      4\u001b[0m __all__ = [\n\u001b[1;32m      5\u001b[0m     \u001b[0mAnalyze\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-            "\u001b[0;32m/usr/local/lib/python3.9/site-packages/paprika/evaluator/analyze.py\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      8\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mnumpy\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0mnp\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      9\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 10\u001b[0;31m \u001b[0;32mfrom\u001b[0m \u001b[0mpaprika\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0manalysis\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mfe_calc\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     11\u001b[0m \u001b[0;32mfrom\u001b[0m \u001b[0mpaprika\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mrestraints\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mDAT_restraint\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     12\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
-            "\u001b[0;32m/usr/local/lib/python3.9/site-packages/paprika/analysis.py\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      8\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mnumpy\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0mnp\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      9\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mpymbar\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 10\u001b[0;31m \u001b[0;32mimport\u001b[0m \u001b[0mpytraj\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0mpt\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     11\u001b[0m \u001b[0;32mfrom\u001b[0m \u001b[0mopenff\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0munits\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0munit\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     12\u001b[0m \u001b[0;32mfrom\u001b[0m \u001b[0mpymbar\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mtimeseries\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-            "\u001b[0;31mModuleNotFoundError\u001b[0m: No module named 'pytraj'",
-            "",
-            "\u001b[0;31m---------------------------------------------------------------------------\u001b[0;32m\nNOTE: If your import is failing due to a missing package, you can\nmanually install dependencies using either !pip or !apt.\n\nTo view examples of installing some common dependencies, click the\n\"Open Examples\" button below.\n\u001b[0;31m---------------------------------------------------------------------------\u001b[0m\n"
-          ],
-          "errorDetails": {
-            "actions": [
-              {
-                "action": "open_url",
-                "actionText": "Open Examples",
-                "url": "/notebooks/snippets/importing_libraries.ipynb"
-              }
-            ]
-          }
-        }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        ""
-      ],
-      "metadata": {
-        "id": "6QHHmmcNs48d"
       },
       "execution_count": null,
       "outputs": []

--- a/docs/tutorials/paprika_colab_init.ipynb
+++ b/docs/tutorials/paprika_colab_init.ipynb
@@ -125,7 +125,7 @@
         "!source /usr/local/etc/profile.d/conda.sh; conda activate paprika\n",
         "!source /usr/local/etc/profile.d/conda.sh; pip install git+https://github.com/slochower/pAPRika.git@master\n",
         "%cd pAPRika\n",
-        "!source /usr/local/etc/profile.d/conda.sh; pip install .",
+        "!source /usr/local/etc/profile.d/conda.sh; pip install .\n",
         "%cd -\n"
       ],
       "metadata": {

--- a/docs/tutorials/paprika_colab_init.ipynb
+++ b/docs/tutorials/paprika_colab_init.ipynb
@@ -171,7 +171,7 @@
     {
       "cell_type": "code",
       "source": [
-        "!source /usr/local/etc/profile.d/conda.sh; pip install pytraj && conda activate paprika\n",
+        "!source /usr/local/etc/profile.d/conda.sh; conda activate paprika\n",
         "import sys\n",
         "sys.path.append('/usr/local/lib/python3.9/site-packages/')"
       ],

--- a/docs/tutorials/paprika_colab_init.ipynb
+++ b/docs/tutorials/paprika_colab_init.ipynb
@@ -111,22 +111,18 @@
       },
       "outputs": [],
       "source": [
-        "!unset PYTHONPATH\n",
-        "!export PATH=\"/root/miniconda/bin:$PATH\"\n",
-        "!source /root/.bashrc"
+        "#!unset PYTHONPATH\n",
+        "#!export PATH=\"/root/miniconda/bin:$PATH\"\n",
+        "#!source /root/.bashrc"
       ]
     },
     {
       "cell_type": "code",
       "source": [
         "!git clone https://github.com/slochower/pAPRika.git\n",
-        "!source /usr/local/etc/profile.d/conda.sh; conda env create --name paprika --file pAPRika/devtools/conda-envs/test_env.yaml && conda list\n",
-        "!source /usr/local/etc/profile.d/conda.sh; conda init bash\n",
-        "!source /usr/local/etc/profile.d/conda.sh; conda activate paprika\n",
-        "!source /usr/local/etc/profile.d/conda.sh; pip install git+https://github.com/slochower/pAPRika.git@master\n",
-        "%cd pAPRika\n",
-        "!source /usr/local/etc/profile.d/conda.sh; pip install .\n",
-        "%cd -\n"
+        "!sed -i -z 's/python\\n/python ==3.9\\n/g' pAPRika/devtools/conda-envs/test_env.yaml\n",
+        "!. /usr/local/etc/profile.d/conda.sh && conda env update --name base --file pAPRika/devtools/conda-envs/test_env.yaml && conda list\n",
+        "!pip install git+https://github.com/slochower/pAPRika.git@master"
       ],
       "metadata": {
         "colab": {
@@ -171,9 +167,10 @@
     {
       "cell_type": "code",
       "source": [
-        "!source /usr/local/etc/profile.d/conda.sh; conda activate paprika\n",
         "import sys\n",
-        "sys.path.append('/usr/local/lib/python3.9/site-packages/')"
+        "import os\n",
+        "sys.path.append('/usr/local/lib/python3.9/site-packages/')\n",
+        "os.environ[\"CUDA_VISIBLE_DEVICES\"] = \"0\""
       ],
       "metadata": {
         "colab": {

--- a/docs/tutorials/paprika_colab_init.ipynb
+++ b/docs/tutorials/paprika_colab_init.ipynb
@@ -124,7 +124,9 @@
         "!source /usr/local/etc/profile.d/conda.sh; conda init bash\n",
         "!source /usr/local/etc/profile.d/conda.sh; conda activate paprika\n",
         "!source /usr/local/etc/profile.d/conda.sh; pip install git+https://github.com/slochower/pAPRika.git@master\n",
-        "!source /usr/local/etc/profile.d/conda.sh; pip install ."
+        "%cd pAPRika\n",
+        "!source /usr/local/etc/profile.d/conda.sh; pip install .",
+        "%cd -\n"
       ],
       "metadata": {
         "colab": {


### PR DESCRIPTION
This adds a script `paprika_colab_init.ipynb` that can be called from a colab notebook to initialize a tutorial. I modeled it after `openff-evaluator`'s colab tutorials.

I didn't change any of the tutorial notebooks, so to make them colab accessible they will need to have this included in the top of the notebooks:
`!wget <link to raw paprika_colab_init.ipynb>`
`%run paprika_colab_init.ipynb`

Also worth noting that the first tutorial still has to be run before any of the others due to the tleap setup of the topologies, etc. For colab, maybe the best solution would be to run the tleap setup in every tutorial? Or maybe try to include the tleap setup in `paprika_colab_init.ipynb`?