### PR TITLE
Improve QOL for Restraints Modules

### DIFF
--- a/paprika/io.py
+++ b/paprika/io.py
@@ -144,7 +144,7 @@ class PaprikaDecoder(json.JSONDecoder):
         if "@type" in obj:
             if obj["@type"] == "openff.units.unit.Quantity":
                 return deserialize_quantity(obj)
-            elif "paprika.restraints" in obj["@type"]:
+            elif "RestraintType" in obj["@type"] or "BiasPotentialType" in obj["@type"]:
                 return deserialize_enum(obj)
 
         return obj

--- a/paprika/io.py
+++ b/paprika/io.py
@@ -117,9 +117,7 @@ class PaprikaEncoder(json.JSONEncoder):
             return obj.tolist()
         elif isinstance(obj, openff_unit.Quantity):
             return serialize_quantity(obj)
-        elif isinstance(obj, RestraintType):
-            return serialize_enum(obj)
-        elif isinstance(obj, BiasPotentialType):
+        elif isinstance(obj, Enum):
             return serialize_enum(obj)
 
         # Let the base class default method raise the TypeError

--- a/paprika/io.py
+++ b/paprika/io.py
@@ -1,8 +1,10 @@
 import base64
+import importlib
 import json
 import logging
 import os
 import traceback
+from enum import Enum
 
 import numpy as np
 import pytraj as pt
@@ -10,12 +12,48 @@ from openff.units import unit as openff_unit
 from parmed import Structure
 from parmed.amber import AmberParm
 
-from paprika.restraints import DAT_restraint
+from paprika.restraints import BiasPotentialType, DAT_restraint, RestraintType
 
 # https://stackoverflow.com/questions/27909658/json-encoder-and-decoder-for-complex-numpy-arrays
 # https://stackoverflow.com/a/24375113/901925
 # https://stackoverflow.com/questions/3488934/simplejson-and-numpy-array/24375113#24375113
+# https://github.com/openforcefield/openff-evaluator/blob/main/openff/evaluator/utils/serialization.py
 logger = logging.getLogger(__name__)
+
+
+def _type_string_to_object(type_string):
+    last_period_index = type_string.rfind(".")
+
+    if last_period_index < 0 or last_period_index == len(type_string) - 1:
+        raise ValueError(
+            "The type string is invalid - it should be of the form "
+            "module_path.class_name: {}".format(type_string)
+        )
+
+    type_string_split = type_string.split(".")
+
+    class_object = None
+    module_path = None
+
+    while len(type_string_split) > 0:
+        class_name = type_string_split.pop(0)
+
+        try:
+            if module_path is None:
+                module_path = class_name
+            else:
+                module_path = module_path + "." + class_name
+
+            # First try and treat the current string as a module
+            module = importlib.import_module(module_path)
+            class_object = module
+
+        except ImportError:
+            # If we get an import error, try then to treat the string
+            # as the name of a nested class.
+            class_object = getattr(class_object, class_name)
+
+    return class_object
 
 
 class PaprikaEncoder(json.JSONEncoder):
@@ -79,6 +117,10 @@ class PaprikaEncoder(json.JSONEncoder):
             return obj.tolist()
         elif isinstance(obj, openff_unit.Quantity):
             return serialize_quantity(obj)
+        elif isinstance(obj, RestraintType):
+            return serialize_enum(obj)
+        elif isinstance(obj, BiasPotentialType):
+            return serialize_enum(obj)
 
         # Let the base class default method raise the TypeError
         # return json.JSONEncoder(self, obj)
@@ -102,7 +144,10 @@ class PaprikaDecoder(json.JSONDecoder):
             return np.frombuffer(data, obj["dtype"]).reshape(obj["shape"])
 
         if "@type" in obj:
-            return deserialize_quantity(obj)
+            if obj["@type"] == "openff.units.unit.Quantity":
+                return deserialize_quantity(obj)
+            elif "paprika.restraints" in obj["@type"]:
+                return deserialize_enum(obj)
 
         return obj
 
@@ -158,6 +203,37 @@ def deserialize_quantity(serialized):
         value_unit = openff_unit(serialized["unit"])
 
     return serialized["value"] * value_unit
+
+
+def serialize_enum(enum):
+    if not isinstance(enum, Enum):
+        raise ValueError("{} is not an Enum".format(type(enum)))
+
+    object_type = type(enum)
+    qualified_name = object_type.__qualname__
+    enum_type = "{}.{}".format(object_type.__module__, qualified_name)
+
+    return {"@type": enum_type, "value": enum.value}
+
+
+def deserialize_enum(enum_dictionary):
+    if "@type" not in enum_dictionary:
+        raise ValueError(
+            "The serialized enum dictionary must include which type the enum is."
+        )
+
+    if "value" not in enum_dictionary:
+        raise ValueError("The serialized enum dictionary must include the enum value.")
+
+    enum_type_string = enum_dictionary["@type"]
+    enum_value = enum_dictionary["value"]
+
+    enum_class = _type_string_to_object(enum_type_string)
+
+    if not issubclass(enum_class, Enum):
+        raise ValueError("<{}> is not an Enum".format(enum_class))
+
+    return enum_class(enum_value)
 
 
 def save_restraints(restraint_list, filepath="restraints.json"):

--- a/paprika/restraints/__init__.py
+++ b/paprika/restraints/__init__.py
@@ -1,13 +1,21 @@
 from .amber import amber_restraint_line
 from .colvars import Colvars
 from .plumed import Plumed
-from .restraints import DAT_restraint, create_window_list, static_DAT_restraint
+from .restraints import (
+    BiasPotentialType,
+    DAT_restraint,
+    RestraintType,
+    static_DAT_restraint,
+)
+from .utils import create_window_list
 
 __all__ = [
+    "BiasPotentialType",
+    "RestraintType",
     "DAT_restraint",
     "amber_restraint_line",
     "static_DAT_restraint",
-    "create_window_list",
     "Plumed",
     "Colvars",
+    "create_window_list",
 ]

--- a/paprika/restraints/amber.py
+++ b/paprika/restraints/amber.py
@@ -37,6 +37,7 @@ def amber_restraint_line(restraint, window):
         r1=     0.0000, r2=     5.9665, r3=     5.9665, r4=   999.0000,
         rk2=   5.0000000, rk3=   5.0000000, &end
     """
+    from paprika.restraints import RestraintType
 
     window, phase = parse_window(window)
     if (
@@ -86,11 +87,11 @@ def amber_restraint_line(restraint, window):
     energy_unit = openff_unit.kcal / openff_unit.mole
     target_unit = (
         openff_unit.angstrom
-        if restraint.restraint_type == "distance"
+        if restraint.restraint_type == RestraintType.Distance
         else openff_unit.degrees
     )
     force_constant_unit = energy_unit / target_unit**2
-    if not restraint.restraint_type == "distance":
+    if not restraint.restraint_type == RestraintType.Distance:
         force_constant_unit = energy_unit / openff_unit.radians**2
 
     # Prepare AMBER NMR-style restraint

--- a/paprika/restraints/restraints.py
+++ b/paprika/restraints/restraints.py
@@ -1,4 +1,5 @@
 import logging
+from enum import Enum
 
 import numpy
 import parmed
@@ -9,6 +10,18 @@ from paprika import utils
 from paprika.utils import check_unit
 
 logger = logging.getLogger(__name__)
+
+
+class BiasPotentialType(Enum):
+    Harmonic = "restraint"
+    UpperWall = "upper_wall"
+    LowerWall = "lower_wall"
+
+
+class RestraintType(Enum):
+    Distance = "distance"
+    Angle = "angle"
+    Torsion = "torsion"
 
 
 class DAT_restraint(object):
@@ -30,7 +43,7 @@ class DAT_restraint(object):
         self._instances = value
 
     @property
-    def restraint_type(self):
+    def restraint_type(self) -> RestraintType:
         """str: The type of restraints for this instance: Distance, Angle or Dihedral."""
         return self._restraint_type
 
@@ -858,19 +871,19 @@ class DAT_restraint(object):
         logger.debug("Assigning atom indices...")
         self.index1 = utils.index_from_mask(self.topology, self.mask1, self.amber_index)
         self.index2 = utils.index_from_mask(self.topology, self.mask2, self.amber_index)
-        self._restraint_type = "distance"
+        self._restraint_type = RestraintType.Distance
         if self.mask3:
             self.index3 = utils.index_from_mask(
                 self.topology, self.mask3, self.amber_index
             )
-            self._restraint_type = "angle"
+            self._restraint_type = RestraintType.Angle
         else:
             self.index3 = None
         if self.mask4:
             self.index4 = utils.index_from_mask(
                 self.topology, self.mask4, self.amber_index
             )
-            self._restraint_type = "torsion"
+            self._restraint_type = RestraintType.Torsion
         else:
             self.index4 = None
         # If any `index` has more than one atom, mark it as a group restraint.
@@ -1124,12 +1137,3 @@ def check_restraints(restraint_list, create_window_list=False):
 
     if create_window_list:
         return window_list
-
-
-def create_window_list(restraint_list):
-    """
-    Create list of APR windows. Runs everything through check_restraints because
-    we need to do that.
-    """
-
-    return check_restraints(restraint_list, create_window_list=True)

--- a/paprika/restraints/utils.py
+++ b/paprika/restraints/utils.py
@@ -3,6 +3,11 @@ import logging
 import numpy as np
 from openff.units import unit as openff_unit
 
+from paprika.restraints.restraints import (
+    BiasPotentialType,
+    RestraintType,
+    check_restraints,
+)
 from paprika.utils import override_dict
 
 logger = logging.getLogger(__name__)
@@ -61,6 +66,13 @@ def get_restraint_values(restraint, phase, window_number):
         Dictionary containing the Amber NMR-style values
 
     """
+
+    if (
+        restraint.phase[phase]["force_constants"] is None
+        and restraint.phase[phase]["targets"] is None
+    ):
+        return None
+
     # Distance bounds
     lower_bound = 0.0 * openff_unit.angstrom
     upper_bound = 999.0 * openff_unit.angstrom
@@ -113,8 +125,8 @@ def get_bias_potential_type(restraint, phase, window_number, return_values=False
 
     Returns
     -------
-    bias_type: str
-        type of bias potential
+    bias_type: paprika.restraints.restraints.BiasPotentialType
+        type of bias potential (`Harmonic`, `UpperWall`, `LowerWall`)
     amber_restraint_values: dict, optional
         restraint values as a dict in Amber NMR format.
     """
@@ -122,24 +134,26 @@ def get_bias_potential_type(restraint, phase, window_number, return_values=False
     bias_type = None
 
     amber_restraint_values = get_restraint_values(restraint, phase, window_number)
+    if amber_restraint_values is None:
+        return bias_type
 
     if (
         amber_restraint_values["r2"] == amber_restraint_values["r3"]
         and amber_restraint_values["rk2"] == amber_restraint_values["rk3"]
     ):
-        bias_type = "restraint"
+        bias_type = BiasPotentialType.Harmonic
 
     elif (
         amber_restraint_values["r2"] < amber_restraint_values["r3"]
         or amber_restraint_values["r2"] == 0.0
     ) and amber_restraint_values["rk2"] == amber_restraint_values["rk3"]:
-        bias_type = "upper_walls"
+        bias_type = BiasPotentialType.UpperWall
 
     elif amber_restraint_values["r2"] == amber_restraint_values["r3"] and (
         amber_restraint_values["rk2"] < amber_restraint_values["rk3"]
         or amber_restraint_values["rk2"] == 0.0
     ):
-        bias_type = "upper_walls"
+        bias_type = BiasPotentialType.UpperWall
 
     elif (
         amber_restraint_values["r2"] < amber_restraint_values["r3"]
@@ -148,25 +162,25 @@ def get_bias_potential_type(restraint, phase, window_number, return_values=False
         amber_restraint_values["rk2"] <= amber_restraint_values["rk3"]
         or amber_restraint_values["rk2"] == 0.0
     ):
-        bias_type = "upper_walls"
+        bias_type = BiasPotentialType.UpperWall
 
     elif (
         amber_restraint_values["r2"] > amber_restraint_values["r3"]
         or amber_restraint_values["r3"] == 0.0
     ) and amber_restraint_values["rk2"] == amber_restraint_values["rk3"]:
-        bias_type = "lower_walls"
+        bias_type = BiasPotentialType.LowerWall
 
     elif amber_restraint_values["r2"] == amber_restraint_values["r3"] and (
         amber_restraint_values["rk2"] > amber_restraint_values["rk3"]
         or amber_restraint_values["rk3"] == 0.0
     ):
-        bias_type = "lower_walls"
+        bias_type = BiasPotentialType.LowerWall
 
     elif (amber_restraint_values["r2"] < amber_restraint_values["r3"]) and (
         amber_restraint_values["rk2"] > amber_restraint_values["rk3"]
         or amber_restraint_values["rk3"] == 0.0
     ):
-        bias_type = "lower_walls"
+        bias_type = BiasPotentialType.LowerWall
 
     if bias_type is None:
         raise Exception("Could not determine bias potential type from restraint.")
@@ -319,7 +333,11 @@ def extract_guest_restraints(
     return guest_restraints
 
 
-def restraints_from_ascii(filename):
+def restraints_from_ascii(
+    filename,
+    delimiter=",",
+    default_units=None,
+):
     """
     Utility function to read in restraints from a simple ASCII file. This is useful
     for using VMD to define restraints. Since you can mouse-click bonds, angles and
@@ -366,8 +384,13 @@ def restraints_from_ascii(filename):
 
     Parameters
     ----------
-    filename : os.PathLike
+    filename : str
         File name of template file.
+    delimiter: str
+        The delimiter used in the text file.
+    default_units: dict
+        The units that the target and force constant is specified in. The keys needed are
+        `distance`, `angle`, `torsion`, `kdist`, and `kangle`.
 
     Returns
     -------
@@ -377,31 +400,42 @@ def restraints_from_ascii(filename):
     """
     restraints = {"atoms": [], "target": [], "k": [], "type": []}
 
+    if default_units is None:
+        default_units = {
+            "distance": openff_unit.angstrom,
+            "angle": openff_unit.degree,
+            "torsion": openff_unit.degree,
+            "kdist": openff_unit.kcal / openff_unit.mol / openff_unit.angstrom**2,
+            "kangle": openff_unit.kcal / openff_unit.mol / openff_unit.radian**2,
+        }
+
     with open(filename, "r") as file:
         for line in file:
             if not line.startswith("#"):
-                line = line.split(",")
+                line = line.split(delimiter)
 
                 # Distance
                 if len(line) == 4:
                     restraints["atoms"].append([line[0], line[1]])
-                    restraints["target"].append(float(line[2]))
-                    restraints["k"].append(float(line[3]))
-                    restraints["type"].append("bond")
+                    restraints["target"].append(
+                        float(line[2]) * default_units["distance"]
+                    )
+                    restraints["k"].append(float(line[3]) * default_units["kdist"])
+                    restraints["type"].append(RestraintType.Distance)
 
                 # Angle
                 elif len(line) == 5:
                     restraints["atoms"].append([line[0], line[1], line[2]])
-                    restraints["target"].append(float(line[3]))
-                    restraints["k"].append(float(line[4]))
-                    restraints["type"].append("angle")
+                    restraints["target"].append(float(line[3]) * default_units["angle"])
+                    restraints["k"].append(float(line[4]) * default_units["kangle"])
+                    restraints["type"].append(RestraintType.Angle)
 
                 # Torsion
                 elif len(line) == 6:
                     restraints["atoms"].append([line[0], line[1], line[2], line[3]])
-                    restraints["target"].append(float(line[4]))
-                    restraints["k"].append(float(line[5]))
-                    restraints["type"].append("dihedral")
+                    restraints["target"].append(float(line[4]) * default_units["angle"])
+                    restraints["k"].append(float(line[5]) * default_units["kangle"])
+                    restraints["type"].append(RestraintType.Torsion)
 
                 else:
                     logger.info(
@@ -409,3 +443,12 @@ def restraints_from_ascii(filename):
                     )
 
     return restraints
+
+
+def create_window_list(restraint_list):
+    """
+    Create list of APR windows. Runs everything through check_restraints because
+    we need to do that.
+    """
+
+    return check_restraints(restraint_list, create_window_list=True)

--- a/paprika/tests/test_analysis.py
+++ b/paprika/tests/test_analysis.py
@@ -82,9 +82,6 @@ def setup_free_energy_calculation():
     rest3.pull["num_windows"] = 19
     rest3.initialize()
 
-    # Create window directories
-    restraints.restraints.create_window_list([rest1, rest2, rest3])
-
     seed = 12345
 
     fecalc = analysis.fe_calc()

--- a/paprika/tests/test_restraints.py
+++ b/paprika/tests/test_restraints.py
@@ -19,12 +19,18 @@ import parmed
 import pytest
 from openff.units import unit as openff_unit
 
+from paprika.restraints import create_window_list
 from paprika.restraints.openmm import apply_dat_restraint, apply_positional_restraints
-from paprika.restraints.restraints import DAT_restraint, create_window_list
+from paprika.restraints.restraints import (
+    BiasPotentialType,
+    DAT_restraint,
+    RestraintType,
+)
 from paprika.restraints.utils import (
     extract_guest_restraints,
     get_bias_potential_type,
     get_restraint_values,
+    restraints_from_ascii,
 )
 from paprika.tests.test_tleap import clean_files
 
@@ -59,6 +65,7 @@ def test_DAT_restraint():
 
     target_units = openff_unit.angstrom
     force_constant_units = openff_unit.kcal / openff_unit.mole / target_units**2
+    assert rest1.restraint_type == RestraintType.Distance
     assert rest1.index1 == [13, 31, 49, 67, 85, 103]
     assert rest1.index2 == [119]
     assert rest1.index3 is None
@@ -130,6 +137,7 @@ def test_DAT_restraint():
     force_constant_units = (
         openff_unit.kcal / openff_unit.mole / openff_unit.radians**2
     )
+    assert rest2.restraint_type == RestraintType.Angle
     assert rest2.index1 == [13, 31, 49, 67, 85, 103]
     assert rest2.index2 == [119]
     assert rest2.index3 == [109]
@@ -200,6 +208,7 @@ def test_DAT_restraint():
     force_constant_units = (
         openff_unit.kcal / openff_unit.mole / openff_unit.radians**2
     )
+    assert rest3.restraint_type == RestraintType.Torsion
     assert rest3.index1 == [31]
     assert rest3.index2 == [13]
     assert rest3.index3 == [119]
@@ -746,6 +755,9 @@ def test_get_restraint_values():
     assert restraint_values["rk2"].magnitude == 1.0
     assert restraint_values["rk3"].magnitude == 1.0
 
+    restraint_values = get_restraint_values(wall, "pull", 0)
+    assert restraint_values is None
+
 
 def test_get_bias_potential_type():
     # Test Harmonic restraint
@@ -771,8 +783,9 @@ def test_get_bias_potential_type():
 
     restraint.initialize()
 
-    assert get_bias_potential_type(restraint, "attach", 0) == "restraint"
-    assert get_bias_potential_type(restraint, "pull", 0) == "restraint"
+    assert get_bias_potential_type(restraint, "attach", 0) == BiasPotentialType.Harmonic
+    assert get_bias_potential_type(restraint, "pull", 0) == BiasPotentialType.Harmonic
+    assert get_bias_potential_type(restraint, "release", 0) is None
 
     # Test upper wall restraint (1)
     upper = DAT_restraint()
@@ -795,8 +808,8 @@ def test_get_bias_potential_type():
 
     upper.initialize()
 
-    assert get_bias_potential_type(upper, "attach", 0) == "upper_walls"
-    assert get_bias_potential_type(upper, "attach", 1) == "upper_walls"
+    assert get_bias_potential_type(upper, "attach", 0) == BiasPotentialType.UpperWall
+    assert get_bias_potential_type(upper, "attach", 1) == BiasPotentialType.UpperWall
 
     # Test upper wall restraint (2)
     upper = DAT_restraint()
@@ -819,8 +832,8 @@ def test_get_bias_potential_type():
 
     upper.initialize()
 
-    assert get_bias_potential_type(upper, "attach", 0) == "upper_walls"
-    assert get_bias_potential_type(upper, "attach", 1) == "upper_walls"
+    assert get_bias_potential_type(upper, "attach", 0) == BiasPotentialType.UpperWall
+    assert get_bias_potential_type(upper, "attach", 1) == BiasPotentialType.UpperWall
 
     # Test upper wall restraint (3)
     upper = DAT_restraint()
@@ -843,8 +856,8 @@ def test_get_bias_potential_type():
 
     upper.initialize()
 
-    assert get_bias_potential_type(upper, "attach", 0) == "upper_walls"
-    assert get_bias_potential_type(upper, "attach", 1) == "upper_walls"
+    assert get_bias_potential_type(upper, "attach", 0) == BiasPotentialType.UpperWall
+    assert get_bias_potential_type(upper, "attach", 1) == BiasPotentialType.UpperWall
 
     # Test lower wall restraint (1)
     lower = DAT_restraint()
@@ -867,8 +880,8 @@ def test_get_bias_potential_type():
 
     lower.initialize()
 
-    assert get_bias_potential_type(lower, "attach", 0) == "lower_walls"
-    assert get_bias_potential_type(lower, "attach", 1) == "lower_walls"
+    assert get_bias_potential_type(lower, "attach", 0) == BiasPotentialType.LowerWall
+    assert get_bias_potential_type(lower, "attach", 1) == BiasPotentialType.LowerWall
 
     # Test lower wall restraint (2)
     lower = DAT_restraint()
@@ -891,8 +904,8 @@ def test_get_bias_potential_type():
 
     lower.initialize()
 
-    assert get_bias_potential_type(lower, "attach", 0) == "lower_walls"
-    assert get_bias_potential_type(lower, "attach", 1) == "lower_walls"
+    assert get_bias_potential_type(lower, "attach", 0) == BiasPotentialType.LowerWall
+    assert get_bias_potential_type(lower, "attach", 1) == BiasPotentialType.LowerWall
 
     # Test lower wall restraint (3)
     lower = DAT_restraint()
@@ -915,8 +928,8 @@ def test_get_bias_potential_type():
 
     lower.initialize()
 
-    assert get_bias_potential_type(lower, "attach", 0) == "lower_walls"
-    assert get_bias_potential_type(lower, "attach", 1) == "lower_walls"
+    assert get_bias_potential_type(lower, "attach", 0) == BiasPotentialType.LowerWall
+    assert get_bias_potential_type(lower, "attach", 1) == BiasPotentialType.LowerWall
 
 
 def test_extract_guest_restraints():
@@ -1705,3 +1718,47 @@ def test_openmm_centroid_and_wall(clean_files):
         force for force in system.getForces() if force.getForceGroup() == 9
     ][0]
     assert "step(theta_0 - theta)" in dihedral_wall_force.getEnergyFunction()
+
+
+def test_restraints_from_ascii(clean_files):
+    code_block = [
+        ":1@C12,:2@C4,12.5,5.0",
+        ":1@O11,:1@C2,:1@C3,90.0,50.0",
+        ":1@C12,:1@O13,:1@C14,1@C15,-121.16,6.0",
+    ]
+    tmp_file = "tmp/restraints.txt"
+    with open(tmp_file, "w") as f:
+        for line in code_block:
+            f.writelines(f"{line}\n")
+
+    restraints_dict = restraints_from_ascii(tmp_file)
+
+    energy_unit = openff_unit.kcal / openff_unit.mol
+    distance_unit = openff_unit.angstrom
+    angle_unit = openff_unit.degree
+    kdist_unit = energy_unit / distance_unit**2
+    kangle_unit = energy_unit / openff_unit.radian**2
+
+    # Distance
+    assert restraints_dict["atoms"][0][0] == ":1@C12"
+    assert restraints_dict["atoms"][0][1] == ":2@C4"
+    assert restraints_dict["target"][0] == 12.5 * distance_unit
+    assert restraints_dict["k"][0] == 5.0 * kdist_unit
+    assert restraints_dict["type"][0] == RestraintType.Distance
+
+    # Angle
+    assert restraints_dict["atoms"][1][0] == ":1@O11"
+    assert restraints_dict["atoms"][1][1] == ":1@C2"
+    assert restraints_dict["atoms"][1][2] == ":1@C3"
+    assert restraints_dict["target"][1] == 90.0 * angle_unit
+    assert restraints_dict["k"][1] == 50.0 * kangle_unit
+    assert restraints_dict["type"][1] == RestraintType.Angle
+
+    # Torsion
+    assert restraints_dict["atoms"][2][0] == ":1@C12"
+    assert restraints_dict["atoms"][2][1] == ":1@O13"
+    assert restraints_dict["atoms"][2][2] == ":1@C14"
+    assert restraints_dict["atoms"][2][3] == "1@C15"
+    assert restraints_dict["target"][2] == -121.16 * angle_unit
+    assert restraints_dict["k"][2] == 6.0 * kangle_unit
+    assert restraints_dict["type"][2] == RestraintType.Torsion

--- a/paprika/tests/test_simulate.py
+++ b/paprika/tests/test_simulate.py
@@ -6,8 +6,7 @@ import pytest
 from openff.units import unit as openff_unit
 
 from paprika import restraints
-from paprika.restraints import amber
-from paprika.restraints.restraints import create_window_list
+from paprika.restraints import amber, create_window_list
 from paprika.simulate import AMBER, GROMACS, NAMD
 from paprika.tests import addons
 from paprika.utils import parse_mden, parse_mdout


### PR DESCRIPTION
This PR add a few quality of life (QOL) improvements to the `restraints` modules. 

- Introduced Enum class `BiasPotentialType` to differentiate a harmonic, upper half-harmonic, and lower half-harmonic potential. This makes it safer than using strings.
- Introduced Enum class `RestraintType` to differentiate distance, angle and torsion restraints.
- `get_restraint_values` - returns a None if `target` and `force_constant` is not defined for the particular phase.
- `get_bias_potential_type` returns a None for the restraint is not defined.
- Moved `create_window_list` from `paprika.restraints.restraints.py` to `paprika.restraints.utils.py`
- Updated the module `restraints_from_ascii` to include units.