### PR TITLE
Fixed some imports using old locations in tutorials

### DIFF
--- a/docs/tutorials/01-tutorial-cb6-but.ipynb
+++ b/docs/tutorials/01-tutorial-cb6-but.ipynb
@@ -897,7 +897,7 @@
    "outputs": [],
    "source": [
     "import os\n",
-    "from paprika.restraints.restraints import create_window_list\n",
+    "from paprika.restraints.utils import create_window_list\n",
     "\n",
     "window_list = create_window_list(guest_restraints)\n",
     "for window in window_list:\n",

--- a/docs/tutorials/02-tutorial-cb6-but-pbc.ipynb
+++ b/docs/tutorials/02-tutorial-cb6-but-pbc.ipynb
@@ -532,7 +532,7 @@
    "outputs": [],
    "source": [
     "import os\n",
-    "from paprika.restraints.restraints import create_window_list\n",
+    "from paprika.restraints.utils import create_window_list\n",
     "\n",
     "window_list = create_window_list(guest_restraints)\n",
     "for window in window_list:\n",

--- a/docs/tutorials/03-tutorial-k-cl.ipynb
+++ b/docs/tutorials/03-tutorial-k-cl.ipynb
@@ -30,7 +30,9 @@
     "from paprika.analysis import fe_calc\n",
     "from paprika.build.system import TLeap\n",
     "from paprika.io import NumpyEncoder\n",
-    "from paprika.restraints import amber_restraint_line, create_window_list, DAT_restraint\n",
+    "from paprika.restraints.restraints import DAT_restraint\n",
+    "from paprika.restraints.amber import amber_restraint_line",
+    "from paprika.restraints.utils import create_window_list",
     "from paprika.simulate import AMBER"
    ]
   },

--- a/docs/tutorials/04-tutorial-cb6-but-openmm.ipynb
+++ b/docs/tutorials/04-tutorial-cb6-but-openmm.ipynb
@@ -460,7 +460,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from paprika.restraints.restraints import create_window_list"
+    "from paprika.restraints.utils import create_window_list"
    ]
   },
   {

--- a/docs/tutorials/05-tutorial-cb6-but-plumed.ipynb
+++ b/docs/tutorials/05-tutorial-cb6-but-plumed.ipynb
@@ -493,7 +493,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from paprika.restraints.restraints import create_window_list"
+    "from paprika.restraints.utils import create_window_list"
    ]
   },
   {

--- a/docs/tutorials/06-tutorial-cb6-but-gromacs.ipynb
+++ b/docs/tutorials/06-tutorial-cb6-but-gromacs.ipynb
@@ -496,7 +496,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from paprika.restraints.restraints import create_window_list"
+    "from paprika.restraints.utils import create_window_list"
    ]
   },
   {

--- a/docs/tutorials/07-tutorial-cb6-but-namd.ipynb
+++ b/docs/tutorials/07-tutorial-cb6-but-namd.ipynb
@@ -448,7 +448,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from paprika.restraints.restraints import create_window_list"
+    "from paprika.restraints.utils import create_window_list"
    ]
   },
   {


### PR DESCRIPTION
Fixed some imports using old locations in tutorials, mostly `paprika.restraints.restraints.create_window_list` --> `paprika.restraints.utils.create_window_list`.