### PR TITLE
Fixing GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,7 +56,7 @@ jobs:
     - name: Install package
       shell: bash -l {0}
       run: |
-        python -m pip install --no-deps .
+        python -m pip install .
 
     - name: Run tests
       shell: bash -l {0}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,7 @@ jobs:
         auto-update-conda: true
         auto-activate-base: false
         miniforge-version: latest
-        miniforge-variant: Mambaforge
+        miniforge-variant: Miniforge
         use-mamba: true
         mamba-version: "*"
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,7 @@ jobs:
         auto-update-conda: true
         auto-activate-base: false
         miniforge-version: latest
-        miniforge-variant: Miniforge
+        miniforge-variant: Miniforge3
         use-mamba: true
         mamba-version: "*"
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,15 +18,15 @@ jobs:
       fail-fast: false
       matrix:
         os: [macOS-latest, ubuntu-latest]
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     env:
       PYVER: ${{ matrix.python-version }}
       PACKAGE: paprika
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
-    - uses: conda-incubator/setup-miniconda@v2
+    - uses: conda-incubator/setup-miniconda@v3
       with:
         python-version: ${{ matrix.python-version }}
         environment-file: devtools/conda-envs/test_env.yaml

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macOS-latest, ubuntu-latest]
+        os: [ubuntu-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     env:
       PYVER: ${{ matrix.python-version }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,11 +38,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -56,7 +56,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -69,6 +69,6 @@ jobs:
     #   ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v3.0.2
-      - uses: actions/setup-python@v4.1.0
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.11'
       - name: Install the package
         run: |
           python setup.py develop --no-deps

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   
   # Base depends
-  - python=3.8
+  - python
   - pip
   - numpy
   - scipy

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   
   # Base depends
-  - python
+  - python=3.8
   - pip
   - numpy
   - scipy
@@ -39,4 +39,5 @@ dependencies:
   # Pip-only installs
   - pip:
     - codecov
-
+    - jax<=0.4.28; python_version == '3.9' # Since python<=3.9 doesn't support `str | None` syntax, pin jax to a version that uses `None` or `Optional[str]`
+    - jaxlib<=0.4.28; python_version == '3.9'

--- a/paprika/__init__.py
+++ b/paprika/__init__.py
@@ -11,6 +11,7 @@ import logging
 
 from paprika.evaluator import Analyze
 
+from . import _version
 # Handle versioneer
 from ._version import get_versions
 
@@ -39,7 +40,5 @@ if setup is None:
     __all__ = ["setup", "analyze"]
 else:
     __all__ = ["analyze"]
-
-from . import _version
 
 __version__ = _version.get_versions()["version"]

--- a/paprika/__init__.py
+++ b/paprika/__init__.py
@@ -11,7 +11,6 @@ import logging
 
 from paprika.evaluator import Analyze
 
-from . import _version
 # Handle versioneer
 from ._version import get_versions
 
@@ -20,7 +19,6 @@ versions = get_versions()
 __version__ = versions["version"]
 __git_revision__ = versions["full-revisionid"]
 del get_versions, versions
-
 
 logger = logging.getLogger(__name__)
 
@@ -33,12 +31,9 @@ except ImportError:
     logging.info("`paprika.setup()` requires OpenMM.")
     setup = None
 
-
 analyze = Analyze
 
 if setup is None:
     __all__ = ["setup", "analyze"]
 else:
     __all__ = ["analyze"]
-
-__version__ = _version.get_versions()["version"]

--- a/paprika/analysis/analysis.py
+++ b/paprika/analysis/analysis.py
@@ -1272,11 +1272,11 @@ class fe_calc(object):
                         phase
                     ][method]["fraction_fe_matrix"][fraction][0, -1]
 
-                    self.results[phase][method]["fraction_sem"][
-                        fraction
-                    ] = self.results[phase][method]["fraction_sem_matrix"][fraction][
-                        0, -1
-                    ]
+                    self.results[phase][method]["fraction_sem"][fraction] = (
+                        self.results[phase][method]["fraction_sem_matrix"][fraction][
+                            0, -1
+                        ]
+                    )
 
                 # Set these higher level (total) values, which will be slightly
                 # easier to access
@@ -1298,23 +1298,23 @@ class fe_calc(object):
                     # Store convergence values, which are helpful for running
                     # simulations
                     windows = len(self.results[phase][method]["sem_matrix"])
-                    self.results[phase][method][
-                        "largest_neighbor"
-                    ] = openff_unit.Quantity(
-                        np.ones([windows], np.float64) * -1.0,
-                        units=self.energy_unit,
+                    self.results[phase][method]["largest_neighbor"] = (
+                        openff_unit.Quantity(
+                            np.ones([windows], np.float64) * -1.0,
+                            units=self.energy_unit,
+                        )
                     )
                     logger.info(f"{phase}: computing largest_neighbor for {method}...")
 
                     for i in range(windows):
                         if i == 0:
-                            self.results[phase][method]["largest_neighbor"][
-                                i
-                            ] = self.results[phase][method]["sem_matrix"][i][i + 1]
+                            self.results[phase][method]["largest_neighbor"][i] = (
+                                self.results[phase][method]["sem_matrix"][i][i + 1]
+                            )
                         elif i == windows - 1:
-                            self.results[phase][method]["largest_neighbor"][
-                                i
-                            ] = self.results[phase][method]["sem_matrix"][i][i - 1]
+                            self.results[phase][method]["largest_neighbor"][i] = (
+                                self.results[phase][method]["sem_matrix"][i][i - 1]
+                            )
                         else:
                             left = self.results[phase][method]["sem_matrix"][i][i - 1]
                             right = self.results[phase][method]["sem_matrix"][i][i + 1]

--- a/paprika/restraints/openmm.py
+++ b/paprika/restraints/openmm.py
@@ -1,4 +1,5 @@
 """A module aimed at applying restraints directly to OpenMM systems."""
+
 import logging
 
 import numpy as np
@@ -67,11 +68,7 @@ def apply_positional_restraints(
             # But then we can't access atom indices. Using `atom.xx` works for
             # coordinates, but is unitless.
             if isinstance(k_pos, float):
-                k = (
-                    k_pos
-                    * openmm_unit.kilocalories_per_mole
-                    / openmm_unit.angstroms**2
-                )
+                k = k_pos * openmm_unit.kilocalories_per_mole / openmm_unit.angstroms**2
             elif isinstance(k_pos, openmm_unit.Quantity):
                 k = k_pos
             elif isinstance(k_pos, openff_unit.Quantity):

--- a/paprika/restraints/restraints.py
+++ b/paprika/restraints/restraints.py
@@ -612,9 +612,9 @@ class DAT_restraint(object):
                 if phase[key] is not None:
                     phase[key] = check_unit(
                         phase[key],
-                        base_unit=target_unit
-                        if key == "target"
-                        else force_constant_unit,
+                        base_unit=(
+                            target_unit if key == "target" else force_constant_unit
+                        ),
                     )
 
         # Check pull units
@@ -637,9 +637,11 @@ class DAT_restraint(object):
                 if key in self._custom_restraint_values:
                     self._custom_restraint_values[key] = check_unit(
                         self._custom_restraint_values[key],
-                        base_unit=force_constant_unit
-                        if key in ["rk2", "rk3"]
-                        else target_unit,
+                        base_unit=(
+                            force_constant_unit
+                            if key in ["rk2", "rk3"]
+                            else target_unit
+                        ),
                     )
                 else:
                     self._custom_restraint_values[key] = None

--- a/paprika/tests/test_evaluator.py
+++ b/paprika/tests/test_evaluator.py
@@ -1,6 +1,7 @@
 """
 Tests evaluator modules.
 """
+
 import logging
 import os
 import shutil

--- a/paprika/tests/test_io.py
+++ b/paprika/tests/test_io.py
@@ -1,6 +1,7 @@
 """
 Test that we can save and load restraints as JSON.
 """
+
 import os
 import shutil
 

--- a/paprika/tests/test_restraints.py
+++ b/paprika/tests/test_restraints.py
@@ -1,6 +1,7 @@
 """
 Tests the restraints utilities.
 """
+
 import logging
 import os
 
@@ -134,9 +135,7 @@ def test_DAT_restraint():
     rest2.initialize()
 
     target_units = openff_unit.degrees
-    force_constant_units = (
-        openff_unit.kcal / openff_unit.mole / openff_unit.radians**2
-    )
+    force_constant_units = openff_unit.kcal / openff_unit.mole / openff_unit.radians**2
     assert rest2.restraint_type == RestraintType.Angle
     assert rest2.index1 == [13, 31, 49, 67, 85, 103]
     assert rest2.index2 == [119]
@@ -205,9 +204,7 @@ def test_DAT_restraint():
     rest3.initialize()
 
     target_units = openff_unit.degrees
-    force_constant_units = (
-        openff_unit.kcal / openff_unit.mole / openff_unit.radians**2
-    )
+    force_constant_units = openff_unit.kcal / openff_unit.mole / openff_unit.radians**2
     assert rest3.restraint_type == RestraintType.Torsion
     assert rest3.index1 == [31]
     assert rest3.index2 == [13]
@@ -278,9 +275,7 @@ def test_DAT_restraint():
     rest4.initialize()
 
     target_units = openff_unit.degrees
-    force_constant_units = (
-        openff_unit.kcal / openff_unit.mole / openff_unit.radians**2
-    )
+    force_constant_units = openff_unit.kcal / openff_unit.mole / openff_unit.radians**2
     assert rest4.index1 == [31]
     assert rest4.index2 == [13]
     assert rest4.index3 == [119]
@@ -348,9 +343,7 @@ def test_DAT_restraint():
     rest5.initialize()
 
     target_units = openff_unit.angstrom
-    force_constant_units = (
-        openff_unit.kcal / openff_unit.mole / openff_unit.angstrom**2
-    )
+    force_constant_units = openff_unit.kcal / openff_unit.mole / openff_unit.angstrom**2
     assert rest5.index1 == [13, 31, 49, 67, 85, 103]
     assert rest5.index2 == [109, 113, 115, 119]
     assert rest5.index3 is None
@@ -417,9 +410,7 @@ def test_DAT_restraint():
     rest6.initialize()
 
     target_units = openff_unit.angstrom
-    force_constant_units = (
-        openff_unit.kcal / openff_unit.mole / openff_unit.angstrom**2
-    )
+    force_constant_units = openff_unit.kcal / openff_unit.mole / openff_unit.angstrom**2
     assert rest6.index1 == [13, 31, 49, 67, 85, 103]
     assert rest6.index2 == [109, 113, 115, 119]
     assert rest6.index3 is None
@@ -484,9 +475,7 @@ def test_DAT_restraint():
     rest7.initialize()
 
     target_units = openff_unit.angstrom
-    force_constant_units = (
-        openff_unit.kcal / openff_unit.mole / openff_unit.angstrom**2
-    )
+    force_constant_units = openff_unit.kcal / openff_unit.mole / openff_unit.angstrom**2
     assert rest7.index1 == [13, 14, 111]
     assert rest7.index2 == [3]
     assert rest7.index3 is None
@@ -547,9 +536,7 @@ def test_DAT_restraint():
     rest8.initialize()
 
     target_units = openff_unit.angstrom
-    force_constant_units = (
-        openff_unit.kcal / openff_unit.mole / openff_unit.angstrom**2
-    )
+    force_constant_units = openff_unit.kcal / openff_unit.mole / openff_unit.angstrom**2
     assert rest8.index1 == [13]
     assert rest8.index2 == [119]
     assert rest8.index3 is None
@@ -587,9 +574,7 @@ def test_DAT_restraint():
     rest9.initialize()
 
     target_units = openff_unit.angstrom
-    force_constant_units = (
-        openff_unit.kcal / openff_unit.mole / openff_unit.angstrom**2
-    )
+    force_constant_units = openff_unit.kcal / openff_unit.mole / openff_unit.angstrom**2
     assert rest9.index1 == [13]
     assert rest9.index2 == [119]
     assert rest9.index3 is None
@@ -627,9 +612,7 @@ def test_DAT_restraint():
     rest10.initialize()
 
     target_units = openff_unit.angstrom
-    force_constant_units = (
-        openff_unit.kcal / openff_unit.mole / openff_unit.angstrom**2
-    )
+    force_constant_units = openff_unit.kcal / openff_unit.mole / openff_unit.angstrom**2
     assert rest10.index1 == [13]
     assert rest10.index2 == [119]
     assert rest10.index3 is None

--- a/paprika/tests/test_tleap.py
+++ b/paprika/tests/test_tleap.py
@@ -1,6 +1,7 @@
 """
 Tests tleap tools.
 """
+
 import logging
 import os
 import random as random

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,10 @@ setup(
     # Extend/modify the list to include/exclude other items as need be
     package_data={"paprika": ["data/*.dat"]},
     include_package_data=True,
-    install_requires=["numpy"],
+    install_requires=[
+        "numpy",
+        "jax<=0.4.28; python_version == '3.9'", # Since python<=3.9 doesn't support `str | None` syntax, pin jax to a version that uses `None` or `Optional[str]`
+    ],
     # Additional entries you may want simply uncomment the lines you want and fill in the data
     # author_email='me@place.org',      # Author email
     # url='http://www.my_package.com',  # Website

--- a/setup.py
+++ b/setup.py
@@ -34,10 +34,7 @@ setup(
     # Extend/modify the list to include/exclude other items as need be
     package_data={"paprika": ["data/*.dat"]},
     include_package_data=True,
-    install_requires=[
-        "numpy",
-        "jax<=0.4.28; python_version == '3.9'", # Since python<=3.9 doesn't support `str | None` syntax, pin jax to a version that uses `None` or `Optional[str]`
-    ],
+    install_requires=["numpy"],
     # Additional entries you may want simply uncomment the lines you want and fill in the data
     # author_email='me@place.org',      # Author email
     # url='http://www.my_package.com',  # Website


### PR DESCRIPTION
This PR aims to get the lint, ci, and codeql workflows working properly. To do so, it was necessary to introduce logic into `devtools/conda-envs/test_env.yaml` that says if python 3.9 is being used, enforce jax and jaxlib <= 0.4.28. This is because jax above that version contains `str | None` type operations, which aren't supported below python 3.10.

Python 3.8 doesn't encounter this issue because it defaults to a jax version way older (~0.4.14) which doesn't contain those type operations (Instead, depending on the version, it will use `Optional[str]` or simply `None` as the type hint).

One small thing I noticed while making these changes:
https://github.com/GilsonLabUCSD/pAPRika/blob/688cc2c19bb88070e4e9f98aa8e23c92817afb57/setup.py#L37
Is including numpy here necessary? Commenting out this line doesn't cause errors for me.